### PR TITLE
Removed getTranslations() method from child interface. fixes #2

### DIFF
--- a/Model/NodeInterface.php
+++ b/Model/NodeInterface.php
@@ -90,5 +90,4 @@ interface NodeInterface extends BaseNodeInterface
      * @return int
      */
     public function getRight();
-
 }


### PR DESCRIPTION
Method `getTranslations()` already defined in parent interface. Interface method override is only working as of PHP 5.3.9. Removed duplicated method to keep compatibility with PHP 5.3.3. This should resolve #2.
